### PR TITLE
fix(db): psql no user "root" error

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -48,6 +48,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    user: postgres
 
 volumes:
   db-data: {}


### PR DESCRIPTION
psql keeps throwing an error if you don't specify the correct user